### PR TITLE
Enable managing project data from detail view

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,0 +1,1282 @@
+const navLinks = document.querySelectorAll('.nav-link');
+const dashboards = document.querySelectorAll('.dashboard');
+const projectTableBody = document.getElementById('projectTableBody');
+const constructionTableBody = document.getElementById('constructionTableBody');
+const mechanicalTableBody = document.getElementById('mechanicalTableBody');
+const assignmentTableBody = document.getElementById('assignmentTableBody');
+const requestGrid = document.getElementById('requestGrid');
+const projectInfo = document.getElementById('projectInfo');
+const productTableBody = document.getElementById('productTableBody');
+const offerTotal = document.getElementById('offerTotal');
+const paymentTotal = document.getElementById('paymentTotal');
+const timeline = document.getElementById('timeline');
+const visitLog = document.getElementById('visitLog');
+const offerLog = document.getElementById('offerLog');
+const paymentLog = document.getElementById('paymentLog');
+const constructionProfile = document.getElementById('constructionProfile');
+const mechanicalProfile = document.getElementById('mechanicalProfile');
+const projectSearch = document.getElementById('projectSearch');
+const constructionSearch = document.getElementById('constructionSearch');
+const mechanicalSearch = document.getElementById('mechanicalSearch');
+const newRecordBtn = document.getElementById('newRecordBtn');
+const newRecordModal = document.getElementById('newRecordModal');
+const closeModal = document.getElementById('closeModal');
+const projectSelector = document.getElementById('projectSelector');
+const newProjectBtn = document.getElementById('newProjectBtn');
+const editProjectBtn = document.getElementById('editProjectBtn');
+const deleteProjectBtn = document.getElementById('deleteProjectBtn');
+const projectForm = document.getElementById('projectForm');
+const productForm = document.getElementById('productForm');
+const timelineForm = document.getElementById('timelineForm');
+
+const counts = {
+  TOKİ: document.getElementById('tokiCount'),
+  'Emlak Konut': document.getElementById('emlakCount'),
+  Özel: document.getElementById('privateCount'),
+  Kamu: document.getElementById('publicCount'),
+};
+
+const projectStore = [
+  {
+    id: 'PRJ-001',
+    addedAt: '2025-02-12',
+    updatedAt: '2025-03-10',
+    category: 'TOKİ',
+    city: 'Adana',
+    name: 'Adana Sarıçam 500 Konut Projesi',
+    contractor: 'ADA Group',
+    mechanical: 'Ada Mekanik',
+    salesStatus: 'Teklif Verildi',
+    manager: 'Çiğdem Tuna',
+    channel: 'direct',
+    channelName: '',
+    scope: '500 Konut + Sosyal Alan',
+    responsibleInstitution: 'TOKİ',
+    progress: 'Teklif değerlendirme aşamasında',
+    assignedTeam: 'Proje Satış',
+    products: [
+      { id: 'prod-001-1', group: 'Plastik', offer: 480000, payment: 0, brand: 'Kalde' },
+      { id: 'prod-001-2', group: 'Esnek Flex', offer: 185000, payment: 0, brand: 'Kalde' },
+      { id: 'prod-001-3', group: 'Altyapı', offer: 325000, payment: 0, brand: 'Kalde' },
+    ],
+    timeline: [
+      {
+        id: 'time-001-1',
+        title: 'Keşif ziyareti gerçekleştirildi',
+        date: '2025-02-12',
+        notes: 'Ada Group şantiye alanı yerinde incelendi. Mekanik ekiplerle ihtiyaç listesi çıkarıldı.',
+      },
+      {
+        id: 'time-001-2',
+        title: 'Teklif teslim edildi',
+        date: '2025-02-28',
+        notes: 'TOKİ ihalesi kapsamında PVC boru ve radyatör ürün grubu için teklif iletildi.',
+      },
+      {
+        id: 'time-001-3',
+        title: 'Geri bildirim bekleniyor',
+        date: '2025-03-10',
+        notes: 'Proje değerlendirme kurulunun dönüşü beklenecek. Takip randevusu 18 Mart olarak planlandı.',
+      },
+    ],
+    visits: [
+      {
+        id: 'visit-001-1',
+        date: '2025-02-12',
+        company: 'ADA Group',
+        contact: 'Ahmet Er',
+        phone: '+90 555 123 45 67',
+        notes: 'Şantiye keşfi yapıldı. Ürün listesi hazırlandı.',
+      },
+    ],
+    offers: [
+      {
+        id: 'offer-001-1',
+        date: '2025-02-28',
+        company: 'ADA Group',
+        contact: 'Ahmet Er',
+        phone: 'ahmet.er@adagroup.com',
+        notes: 'PVC boru ve flex ürünleri için 985.000₺ teklif edildi.',
+      },
+    ],
+    payments: [],
+  },
+  {
+    id: 'PRJ-002',
+    addedAt: '2025-01-25',
+    updatedAt: '2025-02-28',
+    category: 'Emlak Konut',
+    city: 'İstanbul',
+    name: 'İstanbul Finans Şehri Kuleleri',
+    contractor: '123 Yapı A.Ş.',
+    mechanical: 'Breeze Mekanik',
+    salesStatus: 'Sipariş Alındı',
+    manager: 'Metehan Kargılı',
+    channel: 'dealer',
+    channelName: 'İstanbul Anadolu Bayi',
+    scope: 'Ofis + Rezidans',
+    responsibleInstitution: 'Emlak Konut GYO',
+    progress: 'Malzeme sevkiyatı planlanıyor',
+    assignedTeam: 'Mega Projeler',
+    products: [
+      { id: 'prod-002-1', group: 'Sessiz-TR', offer: 650000, payment: 350000, brand: 'Kalde' },
+      { id: 'prod-002-2', group: 'Metal', offer: 420000, payment: 200000, brand: 'Kalde' },
+      { id: 'prod-002-3', group: 'Radyatör', offer: 280000, payment: 0, brand: 'ECA' },
+    ],
+    timeline: [
+      {
+        id: 'time-002-1',
+        title: 'Bayi ile koordinasyon toplantısı',
+        date: '2025-01-15',
+        notes: 'İstanbul Anadolu Bayi proje lojistiğini üstlenecek. Sevkiyat planı çıkarıldı.',
+      },
+      {
+        id: 'time-002-2',
+        title: 'Sipariş onayı alındı',
+        date: '2025-02-28',
+        notes: 'Ürün teslimatı 15 Mart için planlandı. Finans departmanına bilgi verildi.',
+      },
+    ],
+    visits: [
+      {
+        id: 'visit-002-1',
+        date: '2025-01-15',
+        company: '123 Yapı A.Ş.',
+        contact: 'Mert Şahin',
+        phone: '+90 555 987 65 43',
+        notes: 'Bayi ile beraber toplantı gerçekleştirildi.',
+      },
+    ],
+    offers: [],
+    payments: [
+      {
+        id: 'payment-002-1',
+        date: '2025-02-28',
+        company: '123 Yapı A.Ş.',
+        amount: 350000,
+        method: 'Havale',
+        notes: 'İlk parti sevkiyat için ön ödeme alındı.',
+      },
+    ],
+  },
+  {
+    id: 'PRJ-003',
+    addedAt: '2024-12-14',
+    updatedAt: '2025-02-10',
+    category: 'Özel',
+    city: 'Ankara',
+    name: 'Ankara Karma Yaşam Alanı',
+    contractor: 'Mira İnşaat',
+    mechanical: 'Mira Tesisat',
+    salesStatus: 'Görüşme',
+    manager: 'Çiğdem Tuna',
+    channel: 'direct',
+    channelName: '',
+    scope: '250 Konut + AVM',
+    responsibleInstitution: 'Özel',
+    progress: 'Mimari revizyon bekleniyor',
+    assignedTeam: 'Bölge Satış',
+    products: [
+      { id: 'prod-003-1', group: 'Plastik Kolektör', offer: 210000, payment: 0, brand: 'Kalde' },
+      { id: 'prod-003-2', group: 'Ankastre Vana', offer: 98000, payment: 0, brand: 'Kalde' },
+    ],
+    timeline: [
+      {
+        id: 'time-003-1',
+        title: 'Konsept sunumu yapıldı',
+        date: '2025-01-20',
+        notes: 'Mimarlar ve mekanik ekip ile ürün seçimi değerlendirildi.',
+      },
+    ],
+    visits: [],
+    offers: [],
+    payments: [],
+  },
+  {
+    id: 'PRJ-004',
+    addedAt: '2024-11-02',
+    updatedAt: '2025-01-15',
+    category: 'Kamu',
+    city: 'Trabzon',
+    name: 'Trabzon Şehir Hastanesi Isıtma Projesi',
+    contractor: 'Kuzey İnşaat',
+    mechanical: 'Kuzey Teknik',
+    salesStatus: 'Teklif Hazırlanıyor',
+    manager: 'Metehan Kargılı',
+    channel: 'dealer',
+    channelName: 'Karadeniz Bölge Bayi',
+    scope: 'Hastane Mekanik Tesisatı',
+    responsibleInstitution: 'Sağlık Bakanlığı',
+    progress: 'Keşif tamamlandı',
+    assignedTeam: 'Kamu Projeleri',
+    products: [
+      { id: 'prod-004-1', group: 'Metal', offer: 510000, payment: 120000, brand: 'Kalde' },
+      { id: 'prod-004-2', group: 'Altyapı', offer: 380000, payment: 0, brand: 'Kalde' },
+    ],
+    timeline: [
+      {
+        id: 'time-004-1',
+        title: 'Karadeniz Bölge Bayi keşif yaptı',
+        date: '2025-01-08',
+        notes: 'Hastane kazan dairesi ve altyapı hatları ölçüldü.',
+      },
+      {
+        id: 'time-004-2',
+        title: 'Teklif hazırlığı',
+        date: '2025-01-15',
+        notes: 'Sağlık Bakanlığı teknik şartnamelerine göre ürün listesi oluşturuldu.',
+      },
+    ],
+    visits: [],
+    offers: [
+      {
+        id: 'offer-004-1',
+        date: '2025-01-20',
+        company: 'Kuzey İnşaat',
+        contact: 'Derya Kılıç',
+        phone: '+90 312 400 22 11',
+        notes: 'Hastane altyapısı için ürün kalemleri gönderildi.',
+      },
+    ],
+    payments: [
+      {
+        id: 'payment-004-1',
+        date: '2025-02-05',
+        company: 'Karadeniz Bölge Bayi',
+        amount: 120000,
+        method: 'Dekont',
+        notes: 'Bayi üzerinden tahsil edildi.',
+      },
+    ],
+  },
+];
+
+const constructionFirms = [
+  {
+    name: '1923 İnşaat A.Ş.',
+    city: 'İstanbul',
+    contact: 'Ahmet Er (Satın Alma)',
+    status: 'Çalışıyor',
+    owner: 'Çiğdem Tuna',
+    ongoing: [
+      { category: 'TOKİ', project: 'Adana Sarıçam 500 Konut Projesi', units: 500 },
+      { category: 'Emlak Konut', project: 'İstanbul Finans Şehri Kuleleri', units: 420 },
+    ],
+    completed: [
+      { category: 'Özel', project: 'Bursa Panorama Konutları', units: 180 },
+    ],
+  },
+  {
+    name: 'Kardelen Yapı',
+    city: 'Ankara',
+    contact: 'Elif Yurt',
+    status: 'Teklif Aşaması',
+    owner: 'Metehan Kargılı',
+    ongoing: [
+      { category: 'Kamu', project: 'Ankara Belediye Hizmet Binası', units: 1 },
+    ],
+    completed: [],
+  },
+];
+
+const mechanicalFirms = [
+  {
+    name: 'ADA Group Mekanik',
+    city: 'İstanbul',
+    contact: 'Serkan Aydın',
+    status: 'Çalışıyor',
+    owner: 'Çiğdem Tuna',
+    ongoing: [
+      { category: 'TOKİ', project: 'Adana Sarıçam 500 Konut Projesi', units: 500 },
+    ],
+    completed: [],
+  },
+  {
+    name: 'Breeze Mekanik',
+    city: 'İstanbul',
+    contact: 'Cemre Uğur',
+    status: 'Sipariş Teslim Edildi',
+    owner: 'Metehan Kargılı',
+    ongoing: [
+      { category: 'Emlak Konut', project: 'İstanbul Finans Şehri Kuleleri', units: 4 },
+    ],
+    completed: [
+      { category: 'Özel', project: 'Ege Marina Rezidans', units: 120 },
+    ],
+  },
+];
+
+const assignments = [
+  {
+    date: '2025-03-10',
+    person: 'Çiğdem Tuna',
+    category: 'Proje',
+    name: 'Adana Sarıçam 500 Konut Projesi',
+    status: 'Takipte',
+  },
+  {
+    date: '2025-03-05',
+    person: 'Metehan Kargılı',
+    category: 'İnşaat Firması',
+    name: '1923 İnşaat A.Ş.',
+    status: 'Aktif',
+  },
+  {
+    date: '2025-02-18',
+    person: 'Metehan Kargılı',
+    category: 'Mekanik Firması',
+    name: 'Breeze Mekanik',
+    status: 'Sevkiyat',
+  },
+];
+
+const requests = [
+  {
+    title: 'TOKİ Adana Teklif Revizyonu',
+    owner: 'Çiğdem Tuna',
+    due: '18 Mart 2025',
+    status: 'Beklemede',
+  },
+  {
+    title: 'Emlak Konut Finans Onayı',
+    owner: 'Metehan Kargılı',
+    due: '15 Mart 2025',
+    status: 'Onay Sürecinde',
+  },
+  {
+    title: 'Bayi Tahsilat Bildirimi',
+    owner: 'Karadeniz Bölge Bayi',
+    due: '20 Mart 2025',
+    status: 'Ödeme Bekleniyor',
+  },
+];
+
+let selectedProjectId = projectStore[0]?.id ?? null;
+let editingProductId = null;
+let editingTimelineId = null;
+const logEditState = { visit: null, offer: null, payment: null };
+let projectFormMode = null;
+const defaultSubmitLabels = new Map();
+const logForms = {};
+
+function formatCurrency(amount) {
+  return amount.toLocaleString('tr-TR', {
+    style: 'currency',
+    currency: 'TRY',
+    maximumFractionDigits: 0,
+  });
+}
+
+function formatDisplayDate(value) {
+  if (!value) return '-';
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? value : date.toLocaleDateString('tr-TR');
+}
+
+function getProject(projectId) {
+  if (!projectId) return undefined;
+  return projectStore.find((item) => item.id === projectId);
+}
+
+function createId(prefix) {
+  return `${prefix}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function registerDefaultLabel(form) {
+  if (!form) return;
+  const submitBtn = form.querySelector('[data-role="submit"]');
+  if (submitBtn) {
+    defaultSubmitLabels.set(form, submitBtn.textContent);
+  }
+}
+
+function setSubmitLabel(form, label) {
+  if (!form) return;
+  const submitBtn = form.querySelector('[data-role="submit"]');
+  if (submitBtn) {
+    submitBtn.textContent = label;
+  }
+}
+
+function resetSubmitLabel(form) {
+  if (!form) return;
+  const submitBtn = form.querySelector('[data-role="submit"]');
+  if (!submitBtn) return;
+  const defaultLabel = defaultSubmitLabels.get(form);
+  if (defaultLabel) {
+    submitBtn.textContent = defaultLabel;
+  }
+}
+
+function resetProjectForm(hide = true) {
+  if (!projectForm) return;
+  projectForm.reset();
+  projectFormMode = null;
+  if (hide) {
+    projectForm.classList.add('hidden');
+  }
+  resetSubmitLabel(projectForm);
+}
+
+function resetProductForm() {
+  if (!productForm) return;
+  productForm.reset();
+  editingProductId = null;
+  const idField = productForm.querySelector('input[name="productId"]');
+  if (idField) idField.value = '';
+  resetSubmitLabel(productForm);
+}
+
+function resetTimelineForm() {
+  if (!timelineForm) return;
+  timelineForm.reset();
+  editingTimelineId = null;
+  const idField = timelineForm.querySelector('input[name="timelineId"]');
+  if (idField) idField.value = '';
+  resetSubmitLabel(timelineForm);
+}
+
+function resetLogForm(type) {
+  const config = logForms[type];
+  if (!config?.form) return;
+  config.form.reset();
+  const idField = config.form.querySelector('input[name="entryId"]');
+  if (idField) idField.value = '';
+  logEditState[type] = null;
+  resetSubmitLabel(config.form);
+}
+
+function setFormValue(form, name, value) {
+  if (!form) return;
+  const field = form.elements.namedItem(name);
+  if (field) {
+    field.value = value ?? '';
+  }
+}
+
+function openProjectForm(mode, project) {
+  if (!projectForm) return;
+  projectFormMode = mode;
+  projectForm.dataset.mode = mode;
+  projectForm.classList.remove('hidden');
+
+  if (mode === 'edit' && project) {
+    setSubmitLabel(projectForm, 'Güncelle');
+  } else {
+    resetSubmitLabel(projectForm);
+  }
+
+  if (mode === 'create') {
+    projectForm.reset();
+    const today = new Date().toISOString().slice(0, 10);
+    setFormValue(projectForm, 'projectId', '');
+    setFormValue(projectForm, 'projectName', '');
+    setFormValue(projectForm, 'projectCategory', '');
+    setFormValue(projectForm, 'projectCity', '');
+    setFormValue(projectForm, 'addedAt', today);
+    setFormValue(projectForm, 'updatedAt', today);
+    setFormValue(projectForm, 'contractor', '');
+    setFormValue(projectForm, 'mechanical', '');
+    setFormValue(projectForm, 'salesStatus', '');
+    setFormValue(projectForm, 'manager', '');
+    setFormValue(projectForm, 'channel', 'direct');
+    setFormValue(projectForm, 'channelName', '');
+    setFormValue(projectForm, 'scope', '');
+    setFormValue(projectForm, 'responsibleInstitution', '');
+    setFormValue(projectForm, 'assignedTeam', '');
+    setFormValue(projectForm, 'progress', '');
+    setFormValue(projectForm, 'originalId', '');
+  } else if (project) {
+    setFormValue(projectForm, 'projectId', project.id);
+    setFormValue(projectForm, 'projectName', project.name);
+    setFormValue(projectForm, 'projectCategory', project.category);
+    setFormValue(projectForm, 'projectCity', project.city);
+    setFormValue(projectForm, 'addedAt', project.addedAt);
+    setFormValue(projectForm, 'updatedAt', project.updatedAt);
+    setFormValue(projectForm, 'contractor', project.contractor);
+    setFormValue(projectForm, 'mechanical', project.mechanical);
+    setFormValue(projectForm, 'salesStatus', project.salesStatus);
+    setFormValue(projectForm, 'manager', project.manager);
+    setFormValue(projectForm, 'channel', project.channel ?? 'direct');
+    setFormValue(projectForm, 'channelName', project.channelName);
+    setFormValue(projectForm, 'scope', project.scope);
+    setFormValue(projectForm, 'responsibleInstitution', project.responsibleInstitution);
+    setFormValue(projectForm, 'assignedTeam', project.assignedTeam);
+    setFormValue(projectForm, 'progress', project.progress);
+    setFormValue(projectForm, 'originalId', project.id);
+  }
+}
+
+function renderProjectTable(filterText = '') {
+  const query = filterText.toLocaleLowerCase('tr-TR');
+  const filteredProjects = projectStore.filter((project) => {
+    const text = `${project.name} ${project.city} ${project.category}`.toLocaleLowerCase('tr-TR');
+    return text.includes(query);
+  });
+
+  projectTableBody.innerHTML = filteredProjects
+    .map((project) => {
+      const statusClass = project.channel === 'direct' ? 'status-direct' : 'status-dealer';
+      const channelLabel = project.channel === 'direct' ? 'Doğrudan' : `Bayi (${project.channelName ?? 'Belirtilmedi'})`;
+
+      return `
+        <tr data-project-id="${project.id}" class="${project.id === selectedProjectId ? 'is-active' : ''}">
+          <td class="status-chip ${statusClass}">${channelLabel}</td>
+          <td>${formatDisplayDate(project.addedAt)}</td>
+          <td>${formatDisplayDate(project.updatedAt)}</td>
+          <td>${project.category}</td>
+          <td>${project.city}</td>
+          <td>${project.name}</td>
+          <td>${project.contractor}</td>
+          <td>${project.mechanical}</td>
+          <td>${project.salesStatus}</td>
+          <td>${project.manager}</td>
+        </tr>
+      `;
+    })
+    .join('');
+
+  const totals = { TOKİ: 0, 'Emlak Konut': 0, Özel: 0, Kamu: 0 };
+  projectStore.forEach((project) => {
+    if (totals[project.category] !== undefined) {
+      totals[project.category] += 1;
+    }
+  });
+
+  counts['TOKİ'].textContent = totals['TOKİ'];
+  counts['Emlak Konut'].textContent = totals['Emlak Konut'];
+  counts['Özel'].textContent = totals['Özel'];
+  counts['Kamu'].textContent = totals['Kamu'];
+}
+
+function populateProjectSelector() {
+  if (!projectSelector) return;
+  projectSelector.innerHTML = projectStore
+    .map((project) => `<option value="${project.id}">${project.id} — ${project.name}</option>`)
+    .join('');
+
+  if (selectedProjectId) {
+    projectSelector.value = selectedProjectId;
+  }
+}
+
+function renderProjectDetail(projectId) {
+  const project = getProject(projectId);
+  selectedProjectId = project?.id ?? null;
+
+  if (!project) {
+    if (projectSelector) projectSelector.value = '';
+    clearProjectDetails();
+    renderProjectTable(projectSearch?.value ?? '');
+    return;
+  }
+
+  if (projectSelector) {
+    const hasOption = Array.from(projectSelector.options).some((option) => option.value === project.id);
+    if (!hasOption) populateProjectSelector();
+    projectSelector.value = project.id;
+  }
+
+  projectInfo.innerHTML = `
+    <dt>Proje Kodu</dt><dd>${project.id}</dd>
+    <dt>Kategori</dt><dd>${project.category}</dd>
+    <dt>İl</dt><dd>${project.city}</dd>
+    <dt>Eklenme Tarihi</dt><dd>${formatDisplayDate(project.addedAt)}</dd>
+    <dt>Son Güncelleme</dt><dd>${formatDisplayDate(project.updatedAt)}</dd>
+    <dt>Yüklenici</dt><dd>${project.contractor || '-'}</dd>
+    <dt>Mekanik Yüklenici</dt><dd>${project.mechanical || '-'}</dd>
+    <dt>Satış Durumu</dt><dd>${project.salesStatus || '-'}</dd>
+    <dt>Bağlantı Türü</dt><dd>${
+      project.channel === 'direct'
+        ? 'Doğrudan'
+        : `Bayi${project.channelName ? ` (${project.channelName})` : ''}`
+    }</dd>
+    <dt>Kapsam</dt><dd>${project.scope || '-'}</dd>
+    <dt>Sorumlu Kurum</dt><dd>${project.responsibleInstitution || '-'}</dd>
+    <dt>Proje Sorumlusu</dt><dd>${project.manager || '-'}</dd>
+    <dt>Atanan Ekip</dt><dd>${project.assignedTeam || '-'}</dd>
+    <dt>İlerleme</dt><dd>${project.progress || '-'}</dd>
+  `;
+
+  resetProductForm();
+  resetTimelineForm();
+  resetLogForm('visit');
+  resetLogForm('offer');
+  resetLogForm('payment');
+
+  renderProducts(project);
+  renderTimeline(project);
+  renderLogs();
+  renderProjectTable(projectSearch?.value ?? '');
+}
+
+function clearProjectDetails() {
+  if (projectInfo) {
+    projectInfo.innerHTML = '<p class="muted">Proje seçin ya da yeni proje oluşturun.</p>';
+  }
+  if (productTableBody) {
+    productTableBody.innerHTML = '<tr><td colspan="5">Proje seçiniz.</td></tr>';
+  }
+  offerTotal.textContent = '-';
+  paymentTotal.textContent = '-';
+  if (timeline) {
+    timeline.innerHTML = '<p class="muted">Proje seçiniz.</p>';
+  }
+  [visitLog, offerLog, paymentLog].forEach((log) => {
+    if (log) {
+      log.innerHTML = '<li class="muted">Proje seçiniz.</li>';
+    }
+  });
+  resetProductForm();
+  resetTimelineForm();
+  resetLogForm('visit');
+  resetLogForm('offer');
+  resetLogForm('payment');
+}
+
+function renderProducts(project) {
+  if (!productTableBody) return;
+  if (!project || !project.products.length) {
+    productTableBody.innerHTML = '<tr><td colspan="5">Henüz ürün kaydı bulunmuyor.</td></tr>';
+    offerTotal.textContent = '-';
+    paymentTotal.textContent = '-';
+    return;
+  }
+
+  let offerSum = 0;
+  let paymentSum = 0;
+
+  productTableBody.innerHTML = project.products
+    .map((product) => {
+      offerSum += Number(product.offer ?? 0);
+      paymentSum += Number(product.payment ?? 0);
+      return `
+        <tr data-product-id="${product.id}">
+          <td class="table-actions">
+            <button class="ghost-btn" data-action="edit-product">Düzenle</button>
+            <button class="ghost-btn danger" data-action="delete-product">Sil</button>
+          </td>
+          <td>${product.group}</td>
+          <td>${product.offer ? formatCurrency(product.offer) : '-'}</td>
+          <td>${product.payment ? formatCurrency(product.payment) : '-'}</td>
+          <td>${product.brand || '-'}</td>
+        </tr>
+      `;
+    })
+    .join('');
+
+  offerTotal.textContent = formatCurrency(offerSum);
+  paymentTotal.textContent = formatCurrency(paymentSum);
+}
+
+function renderTimeline(project) {
+  if (!timeline) return;
+  if (!project || !project.timeline.length) {
+    timeline.innerHTML = '<p class="muted">Bu proje için henüz süreç kaydı oluşturulmadı.</p>';
+    return;
+  }
+
+  const items = [...project.timeline].sort((a, b) => (a.date < b.date ? 1 : -1));
+  timeline.innerHTML = items
+    .map(
+      (item) => `
+        <article class="timeline-item" data-timeline-id="${item.id}">
+          <div class="timeline-item__content">
+            <strong>${item.title}</strong>
+            <span>${formatDisplayDate(item.date)}</span>
+            <p>${item.notes ?? ''}</p>
+          </div>
+          <div class="timeline-item__actions">
+            <button class="ghost-btn" data-action="edit-timeline">Düzenle</button>
+            <button class="ghost-btn danger" data-action="delete-timeline">Sil</button>
+          </div>
+        </article>
+      `,
+    )
+    .join('');
+}
+
+function renderLogs() {
+  const project = getProject(selectedProjectId);
+
+  renderLogList(
+    visitLog,
+    project?.visits ?? [],
+    'visit',
+    (item) => `
+      <strong>${item.company}</strong>
+      <span>${formatDisplayDate(item.date)}</span>
+      <p>${item.notes ?? ''}</p>
+      <span>Yetkili: ${item.contact}${item.phone ? ' • ' + item.phone : ''}</span>
+    `,
+  );
+
+  renderLogList(
+    offerLog,
+    project?.offers ?? [],
+    'offer',
+    (item) => `
+      <strong>${item.company}</strong>
+      <span>${formatDisplayDate(item.date)}</span>
+      <p>${item.notes ?? ''}</p>
+      <span>Yetkili: ${item.contact}${item.phone ? ' • ' + item.phone : ''}</span>
+    `,
+  );
+
+  renderLogList(
+    paymentLog,
+    project?.payments ?? [],
+    'payment',
+    (item) => `
+      <strong>${item.company}</strong>
+      <span>${formatDisplayDate(item.date)} • ${item.amount ? formatCurrency(item.amount) : '-'}</span>
+      <p>${item.notes ?? ''}</p>
+      <span>Ödeme Yöntemi: ${item.method || '-'}</span>
+    `,
+  );
+}
+
+function renderLogList(target, items, type, templateFn) {
+  if (!target) return;
+  if (!items.length) {
+    target.innerHTML = '<li class="muted">Henüz kayıt bulunmuyor.</li>';
+    return;
+  }
+
+  target.innerHTML = [...items]
+    .sort((a, b) => (a.date < b.date ? 1 : -1))
+    .map(
+      (item) => `
+        <li class="log-item" data-log-id="${item.id}">
+          <div class="log-item__content">${templateFn(item)}</div>
+          <div class="log-item__actions">
+            <button class="ghost-btn" data-action="edit-log" data-log-type="${type}">Düzenle</button>
+            <button class="ghost-btn danger" data-action="delete-log" data-log-type="${type}">Sil</button>
+          </div>
+        </li>
+      `,
+    )
+    .join('');
+}
+
+function activateView(target) {
+  navLinks.forEach((link) => {
+    const isActive = link.dataset.target === target;
+    link.classList.toggle('active', isActive);
+  });
+
+  dashboards.forEach((section) => {
+    section.classList.toggle('hidden', section.dataset.view !== target);
+  });
+}
+
+function renderFirmTable(target, items, searchText = '') {
+  const query = searchText.toLocaleLowerCase('tr-TR');
+  target.innerHTML = items
+    .filter((item) => item.name.toLocaleLowerCase('tr-TR').includes(query))
+    .map(
+      (firm) => `
+        <tr data-firm="${firm.name}">
+          <td><button class="ghost-btn" data-action="view">Detay</button></td>
+          <td>${firm.name}</td>
+          <td>${firm.city}</td>
+          <td>${firm.contact}</td>
+          <td>${firm.status}</td>
+          <td>${firm.owner}</td>
+        </tr>
+      `,
+    )
+    .join('');
+}
+
+function buildFirmProfile(firm) {
+  const ongoing = firm.ongoing
+    .map((item) => `<li><span>${item.category}</span><span>${item.project} (${item.units} konut)</span></li>`)
+    .join('');
+  const completed = firm.completed
+    .map((item) => `<li><span>${item.category}</span><span>${item.project} (${item.units} konut)</span></li>`)
+    .join('');
+
+  return `
+    <h3>${firm.name}</h3>
+    <ul class="profile__list">
+      <li><span>İl</span><span>${firm.city}</span></li>
+      <li><span>Yetkili</span><span>${firm.contact}</span></li>
+      <li><span>Çalışma Durumu</span><span>${firm.status}</span></li>
+      <li><span>Sorumlu Personel</span><span>${firm.owner}</span></li>
+    </ul>
+    <div class="profile__group">
+      <h4>Devam Eden Projeler</h4>
+      <ul class="profile__list">${ongoing || '<li><span>-</span><span>Bilgi yok</span></li>'}</ul>
+    </div>
+    <div class="profile__group">
+      <h4>Tamamlanan Projeler</h4>
+      <ul class="profile__list">${completed || '<li><span>-</span><span>Bilgi yok</span></li>'}</ul>
+    </div>
+  `;
+}
+
+function renderAssignments() {
+  assignmentTableBody.innerHTML = assignments
+    .map(
+      (item) => `
+        <tr>
+          <td>${item.date}</td>
+          <td>${item.person}</td>
+          <td>${item.category}</td>
+          <td>${item.name}</td>
+          <td>${item.status}</td>
+        </tr>
+      `,
+    )
+    .join('');
+}
+
+function renderRequests() {
+  requestGrid.innerHTML = requests
+    .map(
+      (item) => `
+        <article class="request-card">
+          <h3>${item.title}</h3>
+          <span>Sorumlu: <strong>${item.owner}</strong></span>
+          <span>Termin: ${item.due}</span>
+          <span>Durum: ${item.status}</span>
+        </article>
+      `,
+    )
+    .join('');
+}
+
+function setupForms() {
+  const visitForm = document.getElementById('visitForm');
+  const offerForm = document.getElementById('offerForm');
+  const paymentForm = document.getElementById('paymentForm');
+
+  registerDefaultLabel(projectForm);
+  registerDefaultLabel(productForm);
+  registerDefaultLabel(timelineForm);
+  [visitForm, offerForm, paymentForm].forEach((form) => registerDefaultLabel(form));
+
+  logForms.visit = { form: visitForm, collection: 'visits' };
+  logForms.offer = { form: offerForm, collection: 'offers' };
+  logForms.payment = { form: paymentForm, collection: 'payments' };
+
+  newProjectBtn?.addEventListener('click', () => {
+    openProjectForm('create');
+  });
+
+  editProjectBtn?.addEventListener('click', () => {
+    const project = getProject(selectedProjectId);
+    if (!project) return;
+    openProjectForm('edit', project);
+  });
+
+  deleteProjectBtn?.addEventListener('click', () => {
+    const project = getProject(selectedProjectId);
+    if (!project) return;
+    if (!window.confirm(`${project.name} kaydını silmek istediğinize emin misiniz?`)) return;
+    const index = projectStore.findIndex((item) => item.id === project.id);
+    if (index >= 0) {
+      projectStore.splice(index, 1);
+    }
+    selectedProjectId = projectStore[0]?.id ?? null;
+    populateProjectSelector();
+    renderProjectTable(projectSearch?.value ?? '');
+    if (selectedProjectId) {
+      renderProjectDetail(selectedProjectId);
+    } else {
+      clearProjectDetails();
+    }
+  });
+
+  projectSelector?.addEventListener('change', (event) => {
+    const value = event.target.value;
+    renderProjectDetail(value);
+  });
+
+  projectForm?.querySelector('[data-action="cancel-project"]')?.addEventListener('click', () => {
+    resetProjectForm();
+  });
+
+  projectForm?.addEventListener('submit', (event) => {
+    event.preventDefault();
+    const formData = new FormData(projectForm);
+    const projectId = formData.get('projectId')?.trim();
+    if (!projectId) return;
+
+    const payload = {
+      id: projectId,
+      name: formData.get('projectName')?.trim() ?? '',
+      category: formData.get('projectCategory') ?? '',
+      city: formData.get('projectCity')?.trim() ?? '',
+      addedAt: formData.get('addedAt') || '',
+      updatedAt: formData.get('updatedAt') || '',
+      contractor: formData.get('contractor')?.trim() ?? '',
+      mechanical: formData.get('mechanical')?.trim() ?? '',
+      salesStatus: formData.get('salesStatus')?.trim() ?? '',
+      manager: formData.get('manager')?.trim() ?? '',
+      channel: formData.get('channel') ?? 'direct',
+      channelName: formData.get('channelName')?.trim() ?? '',
+      scope: formData.get('scope')?.trim() ?? '',
+      responsibleInstitution: formData.get('responsibleInstitution')?.trim() ?? '',
+      assignedTeam: formData.get('assignedTeam')?.trim() ?? '',
+      progress: formData.get('progress')?.trim() ?? '',
+    };
+
+    const today = new Date().toISOString().slice(0, 10);
+    if (!payload.addedAt) payload.addedAt = today;
+    if (!payload.updatedAt) payload.updatedAt = payload.addedAt;
+
+    if (projectFormMode === 'edit') {
+      const originalId = formData.get('originalId') || selectedProjectId;
+      const project = getProject(originalId);
+      if (!project) return;
+      if (originalId !== projectId && getProject(projectId)) {
+        window.alert('Bu proje kodu zaten kullanılıyor.');
+        return;
+      }
+      project.id = projectId;
+      project.name = payload.name;
+      project.category = payload.category;
+      project.city = payload.city;
+      project.addedAt = payload.addedAt;
+      project.updatedAt = payload.updatedAt;
+      project.contractor = payload.contractor;
+      project.mechanical = payload.mechanical;
+      project.salesStatus = payload.salesStatus;
+      project.manager = payload.manager;
+      project.channel = payload.channel;
+      project.channelName = payload.channelName;
+      project.scope = payload.scope;
+      project.responsibleInstitution = payload.responsibleInstitution;
+      project.assignedTeam = payload.assignedTeam;
+      project.progress = payload.progress;
+      selectedProjectId = project.id;
+    } else {
+      if (getProject(projectId)) {
+        window.alert('Bu proje kodu zaten kullanılıyor.');
+        return;
+      }
+
+      const newProject = {
+        id: payload.id,
+        addedAt: payload.addedAt,
+        updatedAt: payload.updatedAt,
+        category: payload.category,
+        city: payload.city,
+        name: payload.name,
+        contractor: payload.contractor,
+        mechanical: payload.mechanical,
+        salesStatus: payload.salesStatus,
+        manager: payload.manager,
+        channel: payload.channel,
+        channelName: payload.channelName,
+        scope: payload.scope,
+        responsibleInstitution: payload.responsibleInstitution,
+        progress: payload.progress,
+        assignedTeam: payload.assignedTeam,
+        products: [],
+        timeline: [],
+        visits: [],
+        offers: [],
+        payments: [],
+      };
+      projectStore.push(newProject);
+      selectedProjectId = newProject.id;
+    }
+
+    resetProjectForm();
+    populateProjectSelector();
+    renderProjectTable(projectSearch?.value ?? '');
+    renderProjectDetail(selectedProjectId);
+  });
+
+  productForm?.addEventListener('submit', (event) => {
+    event.preventDefault();
+    const project = getProject(selectedProjectId);
+    if (!project) return;
+    const formData = new FormData(productForm);
+    const productId = editingProductId || formData.get('productId') || createId('prod');
+    const payload = {
+      id: productId,
+      group: formData.get('group')?.trim() ?? '',
+      offer: Number(formData.get('offer') || 0),
+      payment: Number(formData.get('payment') || 0),
+      brand: formData.get('brand')?.trim() ?? '',
+    };
+
+    if (editingProductId) {
+      const product = project.products.find((item) => item.id === editingProductId);
+      if (product) {
+        Object.assign(product, payload);
+      }
+    } else {
+      project.products.push(payload);
+    }
+
+    resetProductForm();
+    renderProducts(project);
+  });
+
+  productForm?.querySelector('[data-action="cancel-product"]')?.addEventListener('click', () => {
+    resetProductForm();
+  });
+
+  timelineForm?.addEventListener('submit', (event) => {
+    event.preventDefault();
+    const project = getProject(selectedProjectId);
+    if (!project) return;
+    const formData = new FormData(timelineForm);
+    const timelineId = editingTimelineId || formData.get('timelineId') || createId('time');
+    const payload = {
+      id: timelineId,
+      title: formData.get('title')?.trim() ?? '',
+      date: formData.get('date') || '',
+      notes: formData.get('notes')?.trim() ?? '',
+    };
+
+    if (editingTimelineId) {
+      const item = project.timeline.find((entry) => entry.id === editingTimelineId);
+      if (item) Object.assign(item, payload);
+    } else {
+      project.timeline.push(payload);
+    }
+
+    resetTimelineForm();
+    renderTimeline(project);
+  });
+
+  timelineForm?.querySelector('[data-action="cancel-timeline"]')?.addEventListener('click', () => {
+    resetTimelineForm();
+  });
+
+  Object.entries(logForms).forEach(([type, config]) => {
+    const { form, collection } = config;
+    if (!form) return;
+
+    form.addEventListener('submit', (event) => {
+      event.preventDefault();
+      const project = getProject(selectedProjectId);
+      if (!project) return;
+      const formData = new FormData(form);
+      const isEditing = Boolean(logEditState[type]);
+      const logId = isEditing ? logEditState[type] : createId(type);
+      const entry = {
+        id: logId,
+        date: formData.get('date') || '',
+        company: formData.get('company')?.trim() ?? '',
+        contact: formData.get('contact')?.trim() ?? '',
+        phone: formData.get('phone')?.trim() ?? '',
+        notes: formData.get('notes')?.trim() ?? '',
+      };
+
+      if (type === 'payment') {
+        entry.amount = Number(formData.get('amount') || 0);
+        entry.method = formData.get('method')?.trim() ?? '';
+      }
+
+      if (isEditing) {
+        const target = project[collection].find((item) => item.id === logId);
+        if (target) Object.assign(target, entry);
+      } else {
+        project[collection].push(entry);
+      }
+
+      resetLogForm(type);
+      renderLogs();
+    });
+
+    form.querySelector('[data-action="cancel-log"]')?.addEventListener('click', () => {
+      resetLogForm(type);
+    });
+  });
+
+  if (productTableBody) {
+    productTableBody.addEventListener('click', (event) => {
+      const button = event.target.closest('button[data-action]');
+      if (!button) return;
+      const row = button.closest('tr[data-product-id]');
+      const productId = row?.dataset.productId;
+      const project = getProject(selectedProjectId);
+      if (!project || !productId) return;
+
+      if (button.dataset.action === 'edit-product') {
+        const product = project.products.find((item) => item.id === productId);
+        if (!product) return;
+        editingProductId = productId;
+        setSubmitLabel(productForm, 'Güncelle');
+        setFormValue(productForm, 'productId', product.id);
+        setFormValue(productForm, 'group', product.group);
+        setFormValue(productForm, 'offer', product.offer);
+        setFormValue(productForm, 'payment', product.payment);
+        setFormValue(productForm, 'brand', product.brand);
+      } else if (button.dataset.action === 'delete-product') {
+        if (!window.confirm('Ürün kaydını silmek istediğinize emin misiniz?')) return;
+        project.products = project.products.filter((item) => item.id !== productId);
+        if (editingProductId === productId) {
+          resetProductForm();
+        }
+        renderProducts(project);
+      }
+    });
+  }
+
+  timeline?.addEventListener('click', (event) => {
+    const button = event.target.closest('button[data-action]');
+    if (!button) return;
+    const item = button.closest('.timeline-item[data-timeline-id]');
+    const timelineId = item?.dataset.timelineId;
+    const project = getProject(selectedProjectId);
+    if (!project || !timelineId) return;
+
+    if (button.dataset.action === 'edit-timeline') {
+      const entry = project.timeline.find((record) => record.id === timelineId);
+      if (!entry) return;
+      editingTimelineId = timelineId;
+      setSubmitLabel(timelineForm, 'Güncelle');
+      setFormValue(timelineForm, 'timelineId', entry.id);
+      setFormValue(timelineForm, 'title', entry.title);
+      setFormValue(timelineForm, 'date', entry.date);
+      setFormValue(timelineForm, 'notes', entry.notes);
+    } else if (button.dataset.action === 'delete-timeline') {
+      if (!window.confirm('Süreç kaydını silmek istediğinize emin misiniz?')) return;
+      project.timeline = project.timeline.filter((record) => record.id !== timelineId);
+      if (editingTimelineId === timelineId) {
+        resetTimelineForm();
+      }
+      renderTimeline(project);
+    }
+  });
+
+  [visitLog, offerLog, paymentLog].forEach((list) => {
+    list?.addEventListener('click', (event) => {
+      const button = event.target.closest('button[data-action]');
+      if (!button) return;
+      const type = button.dataset.logType;
+      const logId = button.closest('li[data-log-id]')?.dataset.logId;
+      const project = getProject(selectedProjectId);
+      const config = logForms[type];
+      if (!project || !config || !logId) return;
+      const { collection, form } = config;
+      const index = project[collection].findIndex((entry) => entry.id === logId);
+      if (index === -1) return;
+
+      if (button.dataset.action === 'edit-log') {
+        const entry = project[collection][index];
+        logEditState[type] = logId;
+        setSubmitLabel(form, 'Güncelle');
+        setFormValue(form, 'entryId', entry.id);
+        setFormValue(form, 'date', entry.date);
+        setFormValue(form, 'company', entry.company);
+        setFormValue(form, 'contact', entry.contact);
+        setFormValue(form, 'phone', entry.phone);
+        setFormValue(form, 'notes', entry.notes);
+        if (type === 'payment') {
+          setFormValue(form, 'amount', entry.amount);
+          setFormValue(form, 'method', entry.method);
+        }
+      } else if (button.dataset.action === 'delete-log') {
+        if (!window.confirm('Kaydı silmek istediğinize emin misiniz?')) return;
+        project[collection].splice(index, 1);
+        if (logEditState[type] === logId) {
+          resetLogForm(type);
+        }
+        renderLogs();
+      }
+    });
+  });
+}
+
+function setupNavigation() {
+  navLinks.forEach((link) => {
+    link.addEventListener('click', () => {
+      activateView(link.dataset.target);
+    });
+  });
+}
+
+function setupProjectSelection() {
+  projectTableBody.addEventListener('click', (event) => {
+    const row = event.target.closest('tr[data-project-id]');
+    if (!row) return;
+    const projectId = row.dataset.projectId;
+    renderProjectDetail(projectId);
+    activateView('project-detail');
+  });
+}
+
+function setupFirmSelection() {
+  constructionTableBody.addEventListener('click', (event) => {
+    if (!(event.target instanceof HTMLElement)) return;
+    if (!event.target.matches('button[data-action="view"]')) return;
+    const row = event.target.closest('tr[data-firm]');
+    if (!row) return;
+    const firm = constructionFirms.find((item) => item.name === row.dataset.firm);
+    if (!firm) return;
+    constructionProfile.innerHTML = buildFirmProfile(firm);
+  });
+
+  mechanicalTableBody.addEventListener('click', (event) => {
+    if (!(event.target instanceof HTMLElement)) return;
+    if (!event.target.matches('button[data-action="view"]')) return;
+    const row = event.target.closest('tr[data-firm]');
+    if (!row) return;
+    const firm = mechanicalFirms.find((item) => item.name === row.dataset.firm);
+    if (!firm) return;
+    mechanicalProfile.innerHTML = buildFirmProfile(firm);
+  });
+}
+
+function setupSearch() {
+  projectSearch?.addEventListener('input', (event) => {
+    renderProjectTable(event.target.value);
+  });
+
+  constructionSearch?.addEventListener('input', (event) => {
+    renderFirmTable(constructionTableBody, constructionFirms, event.target.value);
+  });
+
+  mechanicalSearch?.addEventListener('input', (event) => {
+    renderFirmTable(mechanicalTableBody, mechanicalFirms, event.target.value);
+  });
+}
+
+function setupModal() {
+  newRecordBtn?.addEventListener('click', () => {
+    newRecordModal.classList.remove('hidden');
+    document.body.style.overflow = 'hidden';
+  });
+
+  const close = () => {
+    newRecordModal.classList.add('hidden');
+    document.body.style.overflow = '';
+  };
+
+  closeModal?.addEventListener('click', close);
+  newRecordModal?.addEventListener('click', (event) => {
+    if (event.target === newRecordModal) close();
+  });
+}
+
+function init() {
+  renderProjectTable();
+  populateProjectSelector();
+  if (selectedProjectId) {
+    renderProjectDetail(selectedProjectId);
+  } else {
+    clearProjectDetails();
+  }
+  renderFirmTable(constructionTableBody, constructionFirms);
+  renderFirmTable(mechanicalTableBody, mechanicalFirms);
+  renderAssignments();
+  renderRequests();
+  setupNavigation();
+  setupProjectSelection();
+  setupFirmSelection();
+  setupForms();
+  setupSearch();
+  setupModal();
+  activateView('project-pool');
+}
+
+init();

--- a/index.html
+++ b/index.html
@@ -1,0 +1,480 @@
+<!DOCTYPE html>
+<html lang="tr">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Proje Yönetim Platformu</title>
+  <link rel="stylesheet" href="styles.css" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link
+    href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap"
+    rel="stylesheet"
+  />
+</head>
+<body>
+  <header class="topbar">
+    <div class="brand">
+      <span class="brand__logo">K</span>
+      <div class="brand__text">
+        <h1>Kalde</h1>
+        <p>Proje Departmanı</p>
+      </div>
+    </div>
+    <nav class="main-nav">
+      <button class="nav-link active" data-target="project-pool">Proje Veri Havuzu</button>
+      <button class="nav-link" data-target="project-detail">Proje Bilgi</button>
+      <button class="nav-link" data-target="construction-detail">İnşaat Firma Detay</button>
+      <button class="nav-link" data-target="mechanical-detail">Mekanik Firma Detay</button>
+      <button class="nav-link" data-target="assignments">Atamalar</button>
+      <button class="nav-link" data-target="requests">Talepler</button>
+    </nav>
+    <button class="primary-btn" id="newRecordBtn">Yeni Kayıt Ekle</button>
+  </header>
+
+  <main>
+    <section class="dashboard" data-view="project-pool">
+      <div class="search-panel">
+        <label>
+          <span>Proje Arayın</span>
+          <input type="search" id="projectSearch" placeholder="Proje adı, il veya kategori" />
+        </label>
+        <label>
+          <span>İnşaat Firma Arayın</span>
+          <input type="search" id="constructionSearch" placeholder="Firma adı" />
+        </label>
+        <label>
+          <span>Mekanik Firma Arayın</span>
+          <input type="search" id="mechanicalSearch" placeholder="Firma adı" />
+        </label>
+      </div>
+
+      <div class="info-cards">
+        <article class="info-card" data-category="TOKİ">
+          <h2>TOKİ</h2>
+          <p>Toplu Konut İdaresi Başkanlığı projeleri</p>
+          <span class="info-card__count" id="tokiCount">0</span>
+        </article>
+        <article class="info-card" data-category="Emlak Konut">
+          <h2>Emlak Konut</h2>
+          <p>Emlak Konut GYO kapsamındaki projeler</p>
+          <span class="info-card__count" id="emlakCount">0</span>
+        </article>
+        <article class="info-card" data-category="Özel">
+          <h2>Özel Projeler</h2>
+          <p>Özel sektör ve müteahhit projeleri</p>
+          <span class="info-card__count" id="privateCount">0</span>
+        </article>
+        <article class="info-card" data-category="Kamu">
+          <h2>Diğer Kamu</h2>
+          <p>Belediye ve kamu kurum projeleri</p>
+          <span class="info-card__count" id="publicCount">0</span>
+        </article>
+      </div>
+
+      <section class="table-wrapper">
+        <header class="section-header">
+          <h2>Proje Veri Havuzu</h2>
+          <div class="legend">
+            <span><span class="legend-dot direct"></span>Doğrudan</span>
+            <span><span class="legend-dot dealer"></span>Bayi</span>
+          </div>
+        </header>
+        <table>
+          <thead>
+            <tr>
+              <th>İşlem</th>
+              <th>Eklenme Tarihi</th>
+              <th>Son İşlem Tarihi</th>
+              <th>Kategori</th>
+              <th>İl</th>
+              <th>Proje Adı</th>
+              <th>Yüklenici</th>
+              <th>Mekanik Yüklenici</th>
+              <th>Satış</th>
+              <th>Proje Sorumlusu</th>
+            </tr>
+          </thead>
+          <tbody id="projectTableBody"></tbody>
+        </table>
+      </section>
+    </section>
+
+    <section class="dashboard hidden" data-view="project-detail">
+      <div class="detail-grid">
+        <section class="detail-card">
+          <header class="detail-header">
+            <div>
+              <h2>Proje Bilgi</h2>
+              <p class="muted">Projeleri tek noktadan yönetin, bilgileri güncelleyin.</p>
+            </div>
+            <div class="detail-actions">
+              <label class="detail-actions__select">
+                <span>Proje Seç</span>
+                <select id="projectSelector"></select>
+              </label>
+              <button class="ghost-btn" id="newProjectBtn">Yeni</button>
+              <button class="ghost-btn" id="editProjectBtn">Düzenle</button>
+              <button class="ghost-btn danger" id="deleteProjectBtn">Sil</button>
+            </div>
+          </header>
+          <dl id="projectInfo" class="detail-list"></dl>
+          <form id="projectForm" class="edit-form hidden">
+            <input type="hidden" name="originalId" />
+            <div class="edit-form__grid">
+              <label>
+                <span>Proje Kodu</span>
+                <input type="text" name="projectId" required />
+              </label>
+              <label>
+                <span>Proje Adı</span>
+                <input type="text" name="projectName" required />
+              </label>
+              <label>
+                <span>Kategori</span>
+                <select name="projectCategory" required>
+                  <option value="">Seçin</option>
+                  <option value="TOKİ">TOKİ</option>
+                  <option value="Emlak Konut">Emlak Konut</option>
+                  <option value="Özel">Özel</option>
+                  <option value="Kamu">Kamu</option>
+                </select>
+              </label>
+              <label>
+                <span>İl</span>
+                <input type="text" name="projectCity" required />
+              </label>
+              <label>
+                <span>Eklenme Tarihi</span>
+                <input type="date" name="addedAt" />
+              </label>
+              <label>
+                <span>Son Güncelleme</span>
+                <input type="date" name="updatedAt" />
+              </label>
+              <label>
+                <span>Yüklenici</span>
+                <input type="text" name="contractor" />
+              </label>
+              <label>
+                <span>Mekanik Yüklenici</span>
+                <input type="text" name="mechanical" />
+              </label>
+              <label>
+                <span>Satış Durumu</span>
+                <input type="text" name="salesStatus" />
+              </label>
+              <label>
+                <span>Proje Sorumlusu</span>
+                <input type="text" name="manager" />
+              </label>
+              <label>
+                <span>Bağlantı Türü</span>
+                <select name="channel">
+                  <option value="direct">Doğrudan</option>
+                  <option value="dealer">Bayi</option>
+                </select>
+              </label>
+              <label>
+                <span>Bayi / Kanal</span>
+                <input type="text" name="channelName" />
+              </label>
+              <label class="full-width">
+                <span>Kapsam</span>
+                <textarea name="scope" rows="2"></textarea>
+              </label>
+              <label>
+                <span>Sorumlu Kurum</span>
+                <input type="text" name="responsibleInstitution" />
+              </label>
+              <label>
+                <span>Atanan Ekip</span>
+                <input type="text" name="assignedTeam" />
+              </label>
+              <label class="full-width">
+                <span>İlerleme Notu</span>
+                <textarea name="progress" rows="2"></textarea>
+              </label>
+            </div>
+            <div class="form-actions">
+              <button type="submit" class="primary-btn" data-role="submit">Kaydet</button>
+              <button type="button" class="ghost-btn" data-action="cancel-project">İptal</button>
+            </div>
+          </form>
+          <div class="upload-box">
+            <p>Ürün ve proje belgelerini buraya sürükleyin</p>
+            <button class="ghost-btn">Belge Yükle</button>
+          </div>
+        </section>
+
+        <section class="detail-card">
+          <header>
+            <h2>Ürün ve Finans Durumu</h2>
+          </header>
+          <table class="mini-table">
+            <thead>
+              <tr>
+                <th>İşlem</th>
+                <th>Ürün Grubu</th>
+                <th>Teklif Tutarı</th>
+                <th>Tahsilat</th>
+                <th>Marka</th>
+              </tr>
+            </thead>
+            <tbody id="productTableBody"></tbody>
+            <tfoot>
+              <tr>
+                <th></th>
+                <th>Toplam</th>
+                <th id="offerTotal">-</th>
+                <th id="paymentTotal">-</th>
+                <th></th>
+              </tr>
+            </tfoot>
+          </table>
+          <form id="productForm" class="mini-form">
+            <input type="hidden" name="productId" />
+            <div class="mini-form__grid">
+              <label>
+                <span>Ürün Grubu</span>
+                <input type="text" name="group" required />
+              </label>
+              <label>
+                <span>Teklif</span>
+                <input type="number" name="offer" min="0" step="1000" />
+              </label>
+              <label>
+                <span>Tahsilat</span>
+                <input type="number" name="payment" min="0" step="1000" />
+              </label>
+              <label>
+                <span>Marka</span>
+                <input type="text" name="brand" />
+              </label>
+            </div>
+            <div class="form-actions">
+              <button type="submit" class="primary-btn" data-role="submit">Ürün Kaydet</button>
+              <button type="button" class="ghost-btn" data-action="cancel-product">İptal</button>
+            </div>
+          </form>
+        </section>
+
+        <section class="detail-card full-row">
+          <header>
+            <h2>İletişim ve Süreç</h2>
+          </header>
+          <div class="timeline" id="timeline"></div>
+          <form id="timelineForm" class="mini-form">
+            <input type="hidden" name="timelineId" />
+            <div class="mini-form__grid">
+              <label>
+                <span>Başlık</span>
+                <input type="text" name="title" required />
+              </label>
+              <label>
+                <span>Tarih</span>
+                <input type="date" name="date" />
+              </label>
+              <label class="full-width">
+                <span>Not</span>
+                <textarea name="notes" rows="2"></textarea>
+              </label>
+            </div>
+            <div class="form-actions">
+              <button type="submit" class="primary-btn" data-role="submit">Süreç Kaydet</button>
+              <button type="button" class="ghost-btn" data-action="cancel-timeline">İptal</button>
+            </div>
+          </form>
+        </section>
+      </div>
+
+      <div class="form-grid">
+        <section class="form-card">
+          <header>
+            <h3>Ziyaret Ekle</h3>
+          </header>
+          <form id="visitForm">
+            <input type="hidden" name="entryId" />
+            <label>
+              <span>İşlem Tarihi</span>
+              <input type="date" name="date" required />
+            </label>
+            <label>
+              <span>Firma</span>
+              <input type="text" name="company" required />
+            </label>
+            <label>
+              <span>Yetkili</span>
+              <input type="text" name="contact" required />
+            </label>
+            <label>
+              <span>İletişim Bilgisi</span>
+              <input type="text" name="phone" />
+            </label>
+            <label class="full-width">
+              <span>Ziyaret Notları</span>
+              <textarea name="notes" rows="3"></textarea>
+            </label>
+            <div class="form-actions">
+              <button type="submit" class="primary-btn" data-role="submit">Ziyareti Kaydet</button>
+              <button type="button" class="ghost-btn" data-action="cancel-log" data-log-type="visit">İptal</button>
+            </div>
+          </form>
+          <ul class="log-list" id="visitLog"></ul>
+        </section>
+
+        <section class="form-card">
+          <header>
+            <h3>Teklif Ekle</h3>
+          </header>
+          <form id="offerForm">
+            <input type="hidden" name="entryId" />
+            <label>
+              <span>İşlem Tarihi</span>
+              <input type="date" name="date" required />
+            </label>
+            <label>
+              <span>Firma</span>
+              <input type="text" name="company" required />
+            </label>
+            <label>
+              <span>Yetkili</span>
+              <input type="text" name="contact" required />
+            </label>
+            <label>
+              <span>İletişim Bilgisi</span>
+              <input type="text" name="phone" />
+            </label>
+            <label class="full-width">
+              <span>Teklif Notları</span>
+              <textarea name="notes" rows="3"></textarea>
+            </label>
+            <div class="form-actions">
+              <button type="submit" class="primary-btn" data-role="submit">Teklifi Kaydet</button>
+              <button type="button" class="ghost-btn" data-action="cancel-log" data-log-type="offer">İptal</button>
+            </div>
+          </form>
+          <ul class="log-list" id="offerLog"></ul>
+        </section>
+
+        <section class="form-card">
+          <header>
+            <h3>Tahsilat Ekle</h3>
+          </header>
+          <form id="paymentForm">
+            <input type="hidden" name="entryId" />
+            <label>
+              <span>İşlem Tarihi</span>
+              <input type="date" name="date" required />
+            </label>
+            <label>
+              <span>Firma</span>
+              <input type="text" name="company" required />
+            </label>
+            <label>
+              <span>Tahsilat Tutarı (₺)</span>
+              <input type="number" name="amount" min="0" step="0.01" required />
+            </label>
+            <label>
+              <span>Yöntem</span>
+              <input type="text" name="method" placeholder="Havale, EFT, Nakit..." />
+            </label>
+            <label class="full-width">
+              <span>Tahsilat Notları</span>
+              <textarea name="notes" rows="3"></textarea>
+            </label>
+            <div class="form-actions">
+              <button type="submit" class="primary-btn" data-role="submit">Tahsilatı Kaydet</button>
+              <button type="button" class="ghost-btn" data-action="cancel-log" data-log-type="payment">İptal</button>
+            </div>
+          </form>
+          <ul class="log-list" id="paymentLog"></ul>
+        </section>
+      </div>
+    </section>
+
+    <section class="dashboard hidden" data-view="construction-detail">
+      <header class="section-header">
+        <h2>İnşaat Firması Detay</h2>
+      </header>
+      <table>
+        <thead>
+          <tr>
+            <th>İşlemler</th>
+            <th>İnşaat Firmaları</th>
+            <th>İl</th>
+            <th>Yetkili</th>
+            <th>Çalışma Durumu</th>
+            <th>Sorumlu Personel</th>
+          </tr>
+        </thead>
+        <tbody id="constructionTableBody"></tbody>
+      </table>
+      <section class="profile" id="constructionProfile"></section>
+    </section>
+
+    <section class="dashboard hidden" data-view="mechanical-detail">
+      <header class="section-header">
+        <h2>Mekanik Firma Detay</h2>
+      </header>
+      <table>
+        <thead>
+          <tr>
+            <th>İşlemler</th>
+            <th>Mekanik Firmaları</th>
+            <th>İl</th>
+            <th>Yetkili</th>
+            <th>Çalışma Durumu</th>
+            <th>Sorumlu Personel</th>
+          </tr>
+        </thead>
+        <tbody id="mechanicalTableBody"></tbody>
+      </table>
+      <section class="profile" id="mechanicalProfile"></section>
+    </section>
+
+    <section class="dashboard hidden" data-view="assignments">
+      <header class="section-header">
+        <h2>Atamalar</h2>
+      </header>
+      <table>
+        <thead>
+          <tr>
+            <th>Atanma Tarihi</th>
+            <th>Atanan Personel</th>
+            <th>Atanma Kategorisi</th>
+            <th>Proje/Firma İsmi</th>
+            <th>Durum</th>
+          </tr>
+        </thead>
+        <tbody id="assignmentTableBody"></tbody>
+      </table>
+    </section>
+
+    <section class="dashboard hidden" data-view="requests">
+      <header class="section-header">
+        <h2>Talep ve Teklif Raporları</h2>
+        <p class="muted">Güncel teklif, tahsilat ve ziyaret taleplerini buradan takip edin.</p>
+      </header>
+      <div class="request-grid" id="requestGrid"></div>
+    </section>
+  </main>
+
+  <div class="modal hidden" id="newRecordModal">
+    <div class="modal__content">
+      <button class="modal__close" id="closeModal">×</button>
+      <h2>Yeni Kayıt Oluştur</h2>
+      <p>Eklemek istediğiniz kayıt tipini seçin:</p>
+      <div class="modal__actions">
+        <button class="ghost-btn">Proje Kaydı</button>
+        <button class="ghost-btn">İnşaat Firması</button>
+        <button class="ghost-btn">Mekanik Firması</button>
+        <button class="ghost-btn">Ziyaret/Teklif</button>
+      </div>
+      <p class="muted">Detaylı kayıt formları için proje bilgi alanını kullanabilirsiniz.</p>
+    </div>
+  </div>
+
+  <script src="app.js"></script>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,852 @@
+:root {
+  --navy: #1f3c88;
+  --navy-dark: #162b63;
+  --orange: #ff8c32;
+  --orange-dark: #e56f06;
+  --background: #f5f7fb;
+  --muted: #6c7a92;
+  --white: #ffffff;
+  --border: #d8deeb;
+  --success: #2ecc71;
+  --danger: #ff5f5f;
+  font-family: 'Poppins', sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: 'Poppins', sans-serif;
+  background: var(--background);
+  color: #1a2537;
+  line-height: 1.5;
+  min-height: 100vh;
+}
+
+.topbar {
+  background: var(--white);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 2rem;
+  border-bottom: 4px solid var(--navy);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.brand__logo {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--navy);
+  color: var(--white);
+  font-size: 1.4rem;
+  font-weight: 700;
+  border-radius: 50%;
+  width: 3rem;
+  height: 3rem;
+}
+
+.brand__text h1 {
+  font-size: 1.4rem;
+  color: var(--navy);
+}
+
+.brand__text p {
+  font-size: 0.75rem;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.main-nav {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.nav-link {
+  border: none;
+  background: transparent;
+  color: var(--muted);
+  padding: 0.5rem 1rem;
+  font-weight: 500;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.nav-link:hover,
+.nav-link:focus {
+  color: var(--navy);
+}
+
+.nav-link.active {
+  background: linear-gradient(135deg, var(--navy), var(--navy-dark));
+  color: var(--white);
+  box-shadow: 0 10px 18px rgba(31, 60, 136, 0.2);
+}
+
+.primary-btn {
+  background: linear-gradient(135deg, var(--orange), var(--orange-dark));
+  color: var(--white);
+  border: none;
+  padding: 0.65rem 1.4rem;
+  border-radius: 0.8rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.primary-btn:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 18px rgba(229, 111, 6, 0.25);
+}
+
+.ghost-btn {
+  border: 1px solid var(--navy);
+  color: var(--navy);
+  background: transparent;
+  padding: 0.5rem 1.2rem;
+  border-radius: 0.8rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.ghost-btn:hover {
+  background: var(--navy);
+  color: var(--white);
+}
+
+main {
+  padding: 2rem;
+  max-width: 1400px;
+  margin: 0 auto;
+}
+
+.dashboard {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.hidden {
+  display: none !important;
+}
+
+.search-panel {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+}
+
+.search-panel label {
+  background: var(--white);
+  border: 1px solid var(--border);
+  border-radius: 1rem;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  box-shadow: 0 12px 20px rgba(31, 60, 136, 0.05);
+}
+
+.search-panel span {
+  font-size: 0.85rem;
+  color: var(--muted);
+  font-weight: 600;
+  letter-spacing: 0.04em;
+}
+
+.search-panel input {
+  border: none;
+  outline: none;
+  font-size: 1rem;
+  color: var(--navy);
+}
+
+.info-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1rem;
+}
+
+.info-card {
+  background: var(--white);
+  border-radius: 1.2rem;
+  padding: 1.4rem;
+  border: 1px solid var(--border);
+  box-shadow: 0 18px 26px rgba(31, 60, 136, 0.08);
+  position: relative;
+  overflow: hidden;
+  transition: transform 0.2s ease;
+}
+
+.info-card::after {
+  content: '';
+  position: absolute;
+  inset: auto -40px -40px auto;
+  width: 120px;
+  height: 120px;
+  background: radial-gradient(circle at center, rgba(255, 140, 50, 0.2), transparent 70%);
+}
+
+.info-card h2 {
+  color: var(--navy);
+  font-size: 1.1rem;
+  margin-bottom: 0.35rem;
+}
+
+.info-card p {
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+.info-card__count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(255, 140, 50, 0.12);
+  color: var(--orange-dark);
+  font-weight: 600;
+  border-radius: 999px;
+  padding: 0.35rem 0.85rem;
+  margin-top: 1rem;
+}
+
+.info-card:hover {
+  transform: translateY(-4px);
+}
+
+.section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.section-header h2 {
+  color: var(--navy);
+}
+
+.legend {
+  display: flex;
+  gap: 1rem;
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+.legend-dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  display: inline-block;
+  margin-right: 0.35rem;
+}
+
+.legend-dot.direct {
+  background: var(--success);
+}
+
+.legend-dot.dealer {
+  background: var(--orange);
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  background: var(--white);
+  border-radius: 1rem;
+  overflow: hidden;
+  box-shadow: 0 20px 30px rgba(31, 60, 136, 0.08);
+}
+
+table thead {
+  background: linear-gradient(135deg, var(--navy), var(--navy-dark));
+  color: var(--white);
+}
+
+table th,
+table td {
+  padding: 0.9rem 1rem;
+  text-align: left;
+  font-size: 0.9rem;
+}
+
+table tbody tr:nth-child(even) {
+  background: rgba(31, 60, 136, 0.04);
+}
+
+table tbody tr:hover {
+  background: rgba(255, 140, 50, 0.12);
+  cursor: pointer;
+}
+
+table tbody tr.is-active {
+  outline: 2px solid rgba(255, 140, 50, 0.6);
+  background: rgba(255, 140, 50, 0.18);
+}
+
+table td.status-chip {
+  font-weight: 600;
+  color: var(--white);
+  border-radius: 999px;
+  padding: 0.4rem 0.8rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.status-direct {
+  background: rgba(46, 204, 113, 0.95);
+}
+
+.status-dealer {
+  background: rgba(255, 140, 50, 0.95);
+}
+
+.detail-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1.5rem;
+}
+
+.detail-card {
+  background: var(--white);
+  border-radius: 1.2rem;
+  padding: 1.5rem;
+  border: 1px solid var(--border);
+  box-shadow: 0 20px 32px rgba(31, 60, 136, 0.09);
+}
+
+.detail-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.detail-actions {
+  display: flex;
+  gap: 0.75rem;
+  align-items: flex-end;
+  flex-wrap: wrap;
+}
+
+.detail-actions__select {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-size: 0.82rem;
+  color: var(--muted);
+  font-weight: 600;
+}
+
+.detail-actions__select select {
+  border: 1px solid var(--border);
+  border-radius: 0.8rem;
+  padding: 0.5rem 0.8rem;
+  font-size: 0.95rem;
+  color: var(--navy);
+  background: var(--white);
+  min-width: 200px;
+  box-shadow: 0 12px 18px rgba(31, 60, 136, 0.08);
+}
+
+.detail-actions .ghost-btn {
+  padding: 0.45rem 1.1rem;
+  font-size: 0.9rem;
+}
+
+.detail-card header h2,
+.detail-card header h3 {
+  color: var(--navy);
+  margin-bottom: 1rem;
+}
+
+.detail-list {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(120px, 1fr));
+  gap: 0.6rem 1rem;
+  font-size: 0.9rem;
+}
+
+.detail-list dt {
+  color: var(--muted);
+  font-weight: 500;
+}
+
+.detail-list dd {
+  color: var(--navy);
+  font-weight: 600;
+}
+
+.edit-form {
+  margin-top: 1.5rem;
+  background: rgba(31, 60, 136, 0.05);
+  border: 1px solid var(--border);
+  border-radius: 1rem;
+  padding: 1.25rem;
+  display: grid;
+  gap: 1rem;
+}
+
+.edit-form.hidden {
+  display: none;
+}
+
+.edit-form__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 0.75rem 1rem;
+}
+
+.edit-form label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-size: 0.85rem;
+  color: var(--muted);
+  font-weight: 600;
+}
+
+.edit-form input,
+.edit-form textarea,
+.edit-form select {
+  border: 1px solid var(--border);
+  border-radius: 0.8rem;
+  padding: 0.6rem 0.75rem;
+  font-size: 0.95rem;
+  color: var(--navy);
+  background: var(--white);
+}
+
+.edit-form textarea {
+  resize: vertical;
+  min-height: 3.2rem;
+}
+
+.upload-box {
+  margin-top: 1.5rem;
+  padding: 1.2rem;
+  border: 1px dashed var(--navy);
+  border-radius: 1rem;
+  text-align: center;
+  color: var(--muted);
+  background: rgba(31, 60, 136, 0.04);
+  display: grid;
+  gap: 0.5rem;
+}
+
+.mini-table {
+  box-shadow: none;
+  border: 1px solid var(--border);
+}
+
+.mini-table thead {
+  background: rgba(31, 60, 136, 0.9);
+}
+
+.mini-table tfoot {
+  background: rgba(31, 60, 136, 0.05);
+  font-weight: 600;
+}
+
+.mini-form {
+  margin-top: 1rem;
+  border: 1px solid var(--border);
+  border-radius: 1rem;
+  padding: 1rem;
+  background: rgba(31, 60, 136, 0.04);
+  display: grid;
+  gap: 0.75rem;
+}
+
+.mini-form__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 0.75rem;
+}
+
+.mini-form label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  font-size: 0.8rem;
+  color: var(--muted);
+  font-weight: 600;
+}
+
+.mini-form input,
+.mini-form textarea,
+.mini-form select {
+  border: 1px solid var(--border);
+  border-radius: 0.75rem;
+  padding: 0.5rem 0.65rem;
+  font-size: 0.9rem;
+  color: var(--navy);
+  background: var(--white);
+}
+
+.mini-form textarea {
+  resize: vertical;
+  min-height: 3rem;
+}
+
+.table-actions {
+  display: flex;
+  gap: 0.4rem;
+  align-items: center;
+}
+
+.table-actions .ghost-btn {
+  padding: 0.35rem 0.75rem;
+  font-size: 0.8rem;
+}
+
+.full-row {
+  grid-column: 1 / -1;
+}
+
+.timeline {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.timeline-item {
+  background: rgba(31, 60, 136, 0.05);
+  border-left: 4px solid var(--orange);
+  padding: 0.8rem 1rem;
+  border-radius: 0.9rem;
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: flex-start;
+}
+
+.timeline-item__content {
+  display: grid;
+  gap: 0.35rem;
+  flex: 1;
+}
+
+.timeline-item__actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.timeline-item__actions .ghost-btn {
+  padding: 0.35rem 0.8rem;
+  font-size: 0.8rem;
+}
+
+.timeline-item strong {
+  color: var(--navy);
+}
+
+.timeline-item span {
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+.timeline-item p {
+  font-size: 0.88rem;
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.5rem;
+}
+
+.form-card {
+  background: var(--white);
+  border-radius: 1.2rem;
+  padding: 1.5rem;
+  border: 1px solid var(--border);
+  box-shadow: 0 20px 32px rgba(31, 60, 136, 0.08);
+  display: grid;
+  gap: 1rem;
+}
+
+form {
+  display: grid;
+  gap: 0.85rem;
+}
+
+form label {
+  display: grid;
+  gap: 0.35rem;
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+form input,
+form textarea,
+form select {
+  border: 1px solid var(--border);
+  border-radius: 0.8rem;
+  padding: 0.6rem 0.75rem;
+  font-size: 0.95rem;
+  color: var(--navy);
+  background: var(--white);
+}
+
+form textarea {
+  resize: vertical;
+}
+
+form .full-width {
+  grid-column: 1 / -1;
+}
+
+.form-actions {
+  display: flex;
+  gap: 0.75rem;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+}
+
+.ghost-btn.danger {
+  border-color: var(--danger);
+  color: var(--danger);
+}
+
+.ghost-btn.danger:hover {
+  background: var(--danger);
+  color: var(--white);
+}
+
+.log-list {
+  display: grid;
+  gap: 0.5rem;
+  list-style: none;
+}
+
+.log-item {
+  border: 1px solid rgba(31, 60, 136, 0.1);
+  border-radius: 0.9rem;
+  padding: 0.6rem 0.75rem;
+  background: rgba(31, 60, 136, 0.05);
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  align-items: flex-start;
+}
+
+.log-item__content {
+  display: grid;
+  gap: 0.3rem;
+  flex: 1;
+}
+
+.log-item__actions {
+  display: flex;
+  gap: 0.4rem;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.log-item__actions .ghost-btn {
+  padding: 0.35rem 0.8rem;
+  font-size: 0.8rem;
+}
+
+.log-item strong {
+  color: var(--navy);
+  font-size: 0.9rem;
+}
+
+.log-item span {
+  color: var(--muted);
+  font-size: 0.8rem;
+}
+
+.profile {
+  margin-top: 1.5rem;
+  background: var(--white);
+  border: 1px solid var(--border);
+  border-radius: 1.2rem;
+  padding: 1.5rem;
+  box-shadow: 0 20px 32px rgba(31, 60, 136, 0.08);
+}
+
+.profile h3 {
+  color: var(--navy);
+  margin-bottom: 0.75rem;
+}
+
+.profile__list {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.profile__list li {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.9rem;
+  border-bottom: 1px dashed rgba(31, 60, 136, 0.1);
+  padding-bottom: 0.35rem;
+}
+
+.profile__list li span:first-child {
+  color: var(--muted);
+  font-weight: 500;
+}
+
+.profile__list li span:last-child {
+  color: var(--navy);
+  font-weight: 600;
+}
+
+.profile__group {
+  margin-top: 1rem;
+}
+
+.profile__group h4 {
+  color: var(--orange-dark);
+  margin-bottom: 0.5rem;
+}
+
+.request-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.5rem;
+}
+
+.request-card {
+  background: var(--white);
+  border-radius: 1.2rem;
+  border: 1px solid var(--border);
+  padding: 1.4rem;
+  display: grid;
+  gap: 0.75rem;
+  box-shadow: 0 20px 32px rgba(31, 60, 136, 0.08);
+}
+
+.request-card h3 {
+  color: var(--navy);
+}
+
+.request-card span {
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+.request-card strong {
+  font-size: 1.1rem;
+  color: var(--orange-dark);
+}
+
+.table-wrapper,
+.detail-card,
+.form-card,
+.profile,
+.request-card {
+  animation: fadeIn 0.45s ease;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(12, 24, 53, 0.55);
+  display: grid;
+  place-items: center;
+  padding: 1.5rem;
+}
+
+.modal__content {
+  background: var(--white);
+  border-radius: 1.4rem;
+  padding: 2rem;
+  max-width: 420px;
+  width: 100%;
+  display: grid;
+  gap: 1.2rem;
+  position: relative;
+}
+
+.modal__close {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  border: none;
+  background: rgba(31, 60, 136, 0.1);
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  font-size: 1.2rem;
+  cursor: pointer;
+}
+
+.modal__actions {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.muted {
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+@media (max-width: 1024px) {
+  .topbar {
+    flex-wrap: wrap;
+    gap: 1rem;
+  }
+
+  .main-nav {
+    order: 3;
+    width: 100%;
+    justify-content: center;
+  }
+
+  main {
+    padding: 1.5rem;
+  }
+}
+
+@media (max-width: 640px) {
+  .brand__text h1 {
+    font-size: 1.1rem;
+  }
+
+  .topbar {
+    justify-content: center;
+  }
+
+  .primary-btn {
+    width: 100%;
+  }
+
+  table,
+  .mini-table {
+    display: block;
+    overflow-x: auto;
+    white-space: nowrap;
+  }
+}


### PR DESCRIPTION
## Summary
- centralize proje ve ilişik kayıtlarını tek veri yapısında toplayıp proje havuzu ile proje bilgi görünümünü senkronize ettim
- proje bilgi sekmesine seçim, yeni proje oluşturma, düzenleme ve silme formlarını ekledim; ürün, süreç ve log girdileri için düzenleme/silme destekledim
- yeni formlar ve işlem butonları için stilleri genişlettim, veri seçimi yapıldığında detay sekmesini otomatik açtım

## Testing
- not run (statik arayüz)


------
https://chatgpt.com/codex/tasks/task_e_68e6641252f0833396b7947c6733fb9c